### PR TITLE
Flag for parallel and interval

### DIFF
--- a/atmap/__init__.py
+++ b/atmap/__init__.py
@@ -1,5 +1,8 @@
 from re import findall
 from json import dumps
+from dateutil import parser
+from datetime import timedelta
+from itertools import chain
 
 def format_at_commands(commands, at):
     return map(lambda command: "echo %s | at %s" % (dumps(command), at), commands)
@@ -11,12 +14,12 @@ def format_email_output_commands(commands, email):
 def count_arguments(command):
     return len(findall(r"\{\d+\}", command))
 
-def pair_arguments(items, amount):
+def pair_items(items, amount):
     return zip(*[iter(items)]*amount)
 
 def format_command(command, items):
     count = count_arguments(command)
-    paired_arguments_list = pair_arguments(items, count)
+    paired_arguments_list = pair_items(items, count)
     return map(lambda paired_args: command.format(*paired_args), paired_arguments_list)
 
 def atmap(command, items, at, email=None):
@@ -24,3 +27,39 @@ def atmap(command, items, at, email=None):
     if email:
         commands = format_email_output_commands(commands, email)
     return format_at_commands(commands, at)
+
+def check_parameters(*args, **kwargs):
+    if kwargs['parallel'] < 0:
+        raise RuntimeError("can't have a negative amount of parallel jobs!")
+    if kwargs['interval'] < 0:
+        raise RuntimeError("can't have a negative interval time!")
+    if kwargs['parallel'] > 0 and kwargs['interval'] == 0:
+        raise RuntimeError("a limited amount of workers requires an interval greater than 0!")
+
+def create_at_generator(at, interval):
+    dt = parser.parse(at)
+    def at_generator(dt, interval):
+        while True:
+            dt = dt + timedelta(minutes=interval)
+            yield dt.strftime('%H:%M%p %d %b %Y')
+    return at_generator(dt, interval)
+
+def batch_items(items, amount=0):
+    batches = pair_items(items, amount) if amount else [items]
+    left = len(items) % amount
+    if left:
+        batches.append(items[-left:])
+    return batches
+
+def create_batches(items, at, parallel, interval):
+    batches = batch_items(items, parallel)
+    at_generator = create_at_generator(at, interval)
+    return batches, at_generator
+
+def schedule_batches(command, batches, at, email, parallel):
+    return chain(*map(lambda sub_items: atmap(command, sub_items, at.next(), email=email), batches))
+
+def atschedule(command, items, at, email=None, parallel=0, interval=0):
+    check_parameters(parallel=parallel, interval=interval)
+    batches, at = create_batches(items, at, parallel, interval)
+    return schedule_batches(command, batches, at, email, parallel)

--- a/bin/atscheduler.py
+++ b/bin/atscheduler.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from argparse import ArgumentParser
 import sys
 
-from atmap import atmap
+from atmap import atschedule
 
 def get_args():
     parser = ArgumentParser(description="Schedule 'at' commmands")
@@ -11,6 +11,8 @@ def get_args():
     parser.add_argument('items', type=str, nargs='+', help='List of items to run the command with. ')
     parser.add_argument('--at', help='Time to start the command(s)', required=True)
     parser.add_argument('--email', help='Address to email the command\'s output to (optional)')
+    parser.add_argument('-j', help='Jobs that can run at the same time (default is no limit)', default=0, type=int)
+    parser.add_argument('-i', help='Interval in minutes between batches', default=0, type=int)
     return parser.parse_args()
 
 def get_args_from_stdin():
@@ -19,10 +21,8 @@ def get_args_from_stdin():
 
 def main():
     args = get_args()
-
     items = get_args_from_stdin() if args.items == ['-'] else args.items
-    commands = atmap(args.command, items, args.at, args.email)
-    
+    commands = atschedule(args.command, items, args.at, args.email, parallel=args.j, interval=args.i)
     print(*commands, sep='\n')
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ config = {
     'version': '0.1',
     'packages': ['atmap'],
     'name': 'atmap',
-    'scripts': ['bin/atscheduler']
+    'scripts': ['bin/atscheduler'],
+    'install_requires': ['python-dateutil']
 }
 
 setup(**config)

--- a/tests/atmap/test_atmap.py
+++ b/tests/atmap/test_atmap.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from mock import patch
 
-from atmap import atmap, format_command, pair_arguments, count_arguments, format_email_output_commands, format_at_commands
+from atmap import atmap, format_command, pair_items, count_arguments, format_email_output_commands, format_at_commands
 
 class TesFormatAtCommands(TestCase):
     commands = ['echo 1', 'echo "2"']
@@ -37,10 +37,10 @@ class TestCountArguments(TestCase):
         self.assertEqual(ret1, 1)
         self.assertEqual(ret2, 2)
 
-class TestPairArguments(TestCase):
-    def test_pair_arguments_pairs_arguments(self):
-        ret1 = pair_arguments([1, 2, 3, 4], 2)
-        ret2 = pair_arguments([1, 2, 3, 4], 4)
+class TestPairItems(TestCase):
+    def test_pair_items_pairs_arguments(self):
+        ret1 = pair_items([1, 2, 3, 4], 2)
+        ret2 = pair_items([1, 2, 3, 4], 4)
 
         self.assertEqual(ret1, [(1, 2), (3, 4)])
         self.assertEqual(ret2, [(1, 2, 3, 4)])
@@ -52,7 +52,7 @@ class TestFormatCommand(TestCase):
 
         c_args.assert_called_once_with('echo {1}')
 
-    @patch('atmap.pair_arguments')
+    @patch('atmap.pair_items')
     def test_format_command_pairs_arguments(self, p_args):
         ret = format_command('echo {0} {1}', [1, 2, 3, 4])
 

--- a/tests/atmap/test_atschedule.py
+++ b/tests/atmap/test_atschedule.py
@@ -1,0 +1,136 @@
+from unittest import TestCase
+from mock import patch, Mock
+import collections
+
+from atmap import atschedule, schedule_batches, create_batches, \
+    create_at_generator, check_parameters
+
+class TestCheckParameters(TestCase):
+    def test_check_parameters_excepts_when_parallel_less_than_0(self):
+        with self.assertRaises(RuntimeError):
+            check_parameters(parallel=-1, interval=0)
+
+    def test_check_parameters_excepts_when_interval_is_less_than_0(self):
+        with self.assertRaises(RuntimeError):
+            check_parameters(parallel=0, interval=-1)
+
+    def test_check_parameters_excepts_when_parallel_is_positive_but_interval_is_0(self):
+        with self.assertRaises(RuntimeError):
+            check_parameters(parallel=1, interval=0)
+
+class TestCreateAtGenerator(TestCase):
+    def test_create_at_generator_creates_iterable(self):
+        ret = create_at_generator('15:00 29 Sep 2015', 10)
+
+        self.assertIsInstance(ret, collections.Iterable)
+
+    def test_create_at_generator_generates_iterable_that_adds_interval_after_each_load(self):
+        ret = create_at_generator('15:00 29 Sep 2015', 10)
+
+        expected_result = [
+            '15:10PM 29 Sep 2015',
+            '15:20PM 29 Sep 2015',
+            '15:30PM 29 Sep 2015',
+            '15:40PM 29 Sep 2015',
+            '15:50PM 29 Sep 2015'
+        ]
+
+        self.assertEqual(expected_result, map(lambda _: ret.next(), xrange(5)))
+
+
+@patch('atmap.create_at_generator')
+@patch('atmap.batch_items')
+class TestCreateBatches(TestCase):
+
+    items = [1, 2, 3, 4]
+    at = '15:00'
+    parallel = 5
+    interval = 10
+    test_args = [items, at, parallel, interval]
+
+    def test_create_batches_batches_items(self, batch_items, *args):
+        create_batches(*self.test_args)
+
+        batch_items.assert_called_once_with(self.items, self.parallel)
+
+    def test_create_batches_creates_at_generator(self, _, create_at_generator):
+        create_batches(*self.test_args)
+
+        create_at_generator.assert_called_once_with(self.at, self.interval)
+
+    def test_create_batches_return_tuple_of_batches_and_at_generator(self, batch_items, create_at_generator):
+        ret = create_batches(*self.test_args)
+
+        self.assertEqual(ret, (batch_items.return_value, create_at_generator.return_value))
+
+class TestScheduleBatches(TestCase):
+
+    command = 'echo {0} {1}'
+    batches = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
+    at = (x for x in xrange(10))
+    email = 'test@example.com'
+    parallel = 2
+    test_args = [command, batches, at, email, parallel]
+
+    @patch('atmap.atmap')
+    def test_schedule_batches_calls_atmap_for_each_batch(self, atmap):
+        schedule_batches(*self.test_args)
+
+        self.assertEqual(len(self.batches), len(atmap.mock_calls))
+
+    def test_schedule_batches_schedules_batches(self):
+        ret = schedule_batches(*self.test_args)
+
+        expected_result = 'blaap'
+        expected_result = [
+                'echo "(echo 1 2) | mail -s \'at command output\' test@example.com" | at 5', 
+                'echo "(echo 3 4) | mail -s \'at command output\' test@example.com" | at 6', 
+                'echo "(echo 5 6) | mail -s \'at command output\' test@example.com" | at 7', 
+                'echo "(echo 7 8) | mail -s \'at command output\' test@example.com" | at 8',
+                'echo "(echo 9 10) | mail -s \'at command output\' test@example.com" | at 9'
+        ]
+        self.assertEqual(map(lambda x: x, ret), expected_result)
+
+
+@patch('atmap.schedule_batches')
+@patch('atmap.create_batches', return_value=(Mock(), Mock()))
+@patch('atmap.check_parameters')
+class TestAtSchedule(TestCase):
+
+    command = 'echo {0}'
+    items = [1, 2, 3]
+    at = '15:00'
+    test_args = [command, items, at]
+
+    def test_atschedule_checks_parameters(self, check_parameters, *args):
+        atschedule(*self.test_args, parallel=5, interval=10)
+
+        check_parameters.assert_called_once_with(parallel=5, interval=10)
+
+    def test_atschedule_defaults_to_parallel_is_0(self, check_parameters, *args):
+        atschedule(*self.test_args, interval=10)
+        
+        check_parameters.assert_called_once_with(parallel=0, interval=10)
+
+    def test_atschedule_defaults_to_interval_is_0(self, check_parameters, *args):
+        atschedule(*self.test_args, parallel=5)
+        
+        check_parameters.assert_called_once_with(parallel=5, interval=0)
+
+    def test_atschedule_creates_batches(self, _, creates_batches, *args):
+        atschedule(*self.test_args, parallel=5, interval=10)
+
+        creates_batches.assert_called_once_with(self.items, self.at, 5, 10)
+
+    def test_atschedule_schedules_batches(self, _, creates_batches, schedule_batches):
+        atschedule(*self.test_args, email='test@example.com', parallel=5, interval=10)
+        batches, at = creates_batches.return_value
+
+        schedule_batches.assert_called_once_with(
+            self.command, batches, at, 'test@example.com', 5
+        )
+
+    def test_atschedule_returns_results_of_scheduled_batches(self, _1, _2, schedule_batches):
+        ret = atschedule(*self.test_args, email='test@example.com', parallel=5, interval=10)
+
+        self.assertEqual(ret, schedule_batches.return_value)

--- a/tests/bin/test_atscheduler.py
+++ b/tests/bin/test_atscheduler.py
@@ -3,23 +3,23 @@ from mock import patch
 
 from bin.atscheduler import main
 
-@patch('bin.atscheduler.atmap')
+@patch('bin.atscheduler.atschedule')
 @patch('bin.atscheduler.get_args_from_stdin')
 @patch('bin.atscheduler.get_args')
 class TestAtscheduler(TestCase):
-    def test_main_calls_atmap(self, get_args, _, atmap):
+    def test_main_calls_atschedule(self, get_args, _, atschedule):
         args = get_args.return_value
 
         main()
 
-        atmap.assert_called_once_with(args.command, args.items, args.at, args.email)
+        atschedule.assert_called_once_with(args.command, args.items, args.at, args.email, parallel=args.j, interval=args.i)
 
-    def test_main_reads_from_stdin_if_stdin_marker_is_specified(self, get_args, get_from_stdin, atmap):
+    def test_main_reads_from_stdin_if_stdin_marker_is_specified(self, get_args, get_from_stdin, atschedule):
         args = get_args.return_value
         args.items = ['-']
 
         main()
 
         get_from_stdin.assert_called_once_with()
-        atmap.assert_called_once_with(args.command, get_from_stdin.return_value, args.at, args.email)
+        atschedule.assert_called_once_with(args.command, get_from_stdin.return_value, args.at, args.email, parallel=args.j, interval=args.i)
 


### PR DESCRIPTION
Specify how many of the jobs should run at the same time and at what
interval (in minutes) the batches should run

example: 3 at a time, 2 minutes apart

```
seq 10 | ./bin/atscheduler --at '21:28:40' 'echo {0}' - -i 3 -j 2
echo "echo 1" | at 21:31PM 28 Sep 2015
echo "echo 2" | at 21:31PM 28 Sep 2015
echo "echo 3" | at 21:34PM 28 Sep 2015
echo "echo 4" | at 21:34PM 28 Sep 2015
echo "echo 5" | at 21:37PM 28 Sep 2015
echo "echo 6" | at 21:37PM 28 Sep 2015
echo "echo 7" | at 21:40PM 28 Sep 2015
echo "echo 8" | at 21:40PM 28 Sep 2015
echo "echo 9" | at 21:43PM 28 Sep 2015
echo "echo 10" | at 21:43PM 28 Sep 2015
```

proof of concept, no tests