### PR TITLE
count {} formatting identifiers

### DIFF
--- a/atmap/__init__.py
+++ b/atmap/__init__.py
@@ -12,7 +12,9 @@ def format_email_output_commands(commands, email):
             (command, email), commands)
 
 def count_arguments(command):
-    return len(set(findall(r"\{\d+\}", command)))
+    with_index = len(set(findall(r"\{\d+\}", command)))
+    no_index = len(findall(r"\{\}", command))
+    return with_index + no_index
 
 def group_n_elements(elements, n=1):
     groups = map(list, zip(*[iter(elements)]*n))

--- a/tests/atmap/test_atmap.py
+++ b/tests/atmap/test_atmap.py
@@ -33,9 +33,11 @@ class TestCountArguments(TestCase):
     def test_count_arguments_counts_arguments(self):
         ret1 = count_arguments('echo {0}')
         ret2 = count_arguments('echo {0} {1}')
+        ret3 = count_arguments('echo {}')
 
         self.assertEqual(ret1, 1)
         self.assertEqual(ret2, 2)
+        self.assertEqual(ret3, 1)
 
 class TestGroupItems(TestCase):
     def test_group_items_pairs_arguments(self):


### PR DESCRIPTION
without \d+ between the curlies

before:
echo {} <- this was ignored
echo {0} {1} <- this was fine